### PR TITLE
Fix UMAP crashes: upgrade annembed and add panic safety

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 [[package]]
 name = "annembed"
 version = "0.1.5"
-source = "git+https://github.com/scientist-labs/annembed?tag=clusterkit-0.1.1#7a5803405087c10c82185f113e3befb953cc9bab"
+source = "git+https://github.com/scientist-labs/annembed?tag=clusterkit-0.2.6#8f8c451367b3a20817cc9dd9803c56aa0c2b9859"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",

--- a/ext/clusterkit/Cargo.toml
+++ b/ext/clusterkit/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 magnus = { version = "0.8", features = ["embed"] }
-annembed = { git = "https://github.com/scientist-labs/annembed", tag = "clusterkit-0.1.1" }
+annembed = { git = "https://github.com/scientist-labs/annembed", tag = "clusterkit-0.2.6" }
 hnsw_rs = { git = "https://github.com/scientist-labs/hnswlib-rs", tag = "clusterkit-0.1.0" }
 hdbscan = "0.11"
 ndarray = "0.16"

--- a/ext/clusterkit/src/embedder.rs
+++ b/ext/clusterkit/src/embedder.rs
@@ -178,9 +178,28 @@ impl RustUMAP {
         // Create embedder and perform embedding
         let mut embedder = Embedder::new(&kgraph, embed_params);
 
-        let embed_result = embedder.embed()
-            .map_err(|e| Error::new(ruby.exception_runtime_error(),
-                format!("Embedding failed: {}", e)))?;
+        let embed_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            embedder.embed()
+        }));
+
+        let embed_result = match embed_result {
+            Ok(Ok(result)) => result,
+            Ok(Err(e)) => {
+                return Err(Error::new(ruby.exception_runtime_error(),
+                    format!("Embedding failed: {}", e)));
+            }
+            Err(panic_info) => {
+                let msg = if let Some(s) = panic_info.downcast_ref::<String>() {
+                    s.clone()
+                } else if let Some(s) = panic_info.downcast_ref::<&str>() {
+                    s.to_string()
+                } else {
+                    "unknown panic".to_string()
+                };
+                return Err(Error::new(ruby.exception_runtime_error(),
+                    format!("Embedding panicked: {}", msg)));
+            }
+        };
 
         if embed_result == 0 {
             return Err(Error::new(ruby.exception_runtime_error(), "No points were embedded"));


### PR DESCRIPTION
## Summary

- Upgrade `annembed` dependency from `clusterkit-0.1.1` to `clusterkit-0.2.6`, which fixes multiple UMAP embedding crashes (see [scientist-labs/annembed#9](https://github.com/scientist-labs/annembed/pull/9))
- Wrap `embedder.embed()` in `catch_unwind` so any remaining Rust panics become Ruby `RuntimeError` exceptions instead of killing the process

### Bugs fixed in annembed clusterkit-0.2.6

1. **LAPACK SGESDD parameter 12 crash** — SVD received wrong matrix layout (Fortran data declared as C-order)
2. **ndarray index-out-of-bounds in diffusion maps** — off-by-one when accessing eigenvectors/eigenvalues with `[j+1]` offset
3. **Dimension mismatch in entropy optimization** — `asked_dim` used to read vectors that could have fewer columns
4. **Empty neighbor array panics** — unguarded `neighbours[0]` access

## Test plan

- [x] Rust tests pass: `cargo test --no-default-features --features macos-accelerate` (2 passed)
- [x] Ruby specs pass: `bundle exec rspec` (465 passed, 0 failures)
- [x] End-to-end: `ragnar umap train` with 6938 embeddings (768 dims) completes successfully
- [x] Previously crashed with both LAPACK fatal error and index-out-of-bounds panic


🤖 Generated with [Claude Code](https://claude.com/claude-code)