### PR TITLE
Fix: drop magnus "embed" feature (precompiled darwin libruby link)

### DIFF
--- a/ext/clusterkit/Cargo.toml
+++ b/ext/clusterkit/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-magnus = { version = "0.8", features = ["embed"] }
-annembed = { git = "https://github.com/scientist-labs/annembed", tag = "clusterkit-0.2.6" }
+magnus = "0.8"annembed = { git = "https://github.com/scientist-labs/annembed", tag = "clusterkit-0.2.6" }
 hnsw_rs = { git = "https://github.com/scientist-labs/hnswlib-rs", tag = "clusterkit-0.1.0" }
 hdbscan = "0.11"
 ndarray = "0.16"


### PR DESCRIPTION
The `embed` feature on the magnus dependency expands to `rb-sys/link-ruby`, which makes rb-sys link the build machine's shared libruby by ABSOLUTE path instead of using the default `-undefined dynamic_lookup`. On the CI runner (ruby/setup-ruby, `--enable-shared`) that baked `/Users/runner/hostedtoolcache/Ruby/<v>/arm64/lib/libruby.X.dylib` into the precompiled arm64-darwin bundle, so it failed to load on any other Mac (confirmed via `otool -L`). `embed` is only for embedding Ruby in a standalone Rust binary, never for an extension cdylib. Dropping it restores dynamic_lookup so Ruby symbols resolve from the host process at load time. Validated against tokenkit (no embed -> portable). Released first as a prerelease for smoke-testing on Mac + Linux.