### PR TITLE
Fix Cargo.toml: split merged magnus/annembed line

### DIFF
--- a/ext/clusterkit/Cargo.toml
+++ b/ext/clusterkit/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-magnus = "0.8"annembed = { git = "https://github.com/scientist-labs/annembed", tag = "clusterkit-0.2.6" }
+magnus = "0.8"
+annembed = { git = "https://github.com/scientist-labs/annembed", tag = "clusterkit-0.2.6" }
 hnsw_rs = { git = "https://github.com/scientist-labs/hnswlib-rs", tag = "clusterkit-0.1.0" }
 hdbscan = "0.11"
 ndarray = "0.16"


### PR DESCRIPTION
The earlier embed-removal commit joined the magnus and annembed lines, making Cargo.toml invalid and failing the build. This restores the line break.